### PR TITLE
server-routing-for-client

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
+    plugins: ["transform-inline-environment-variables"],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,6 +3178,12 @@
         "babel-template": "^6.24.1"
       }
     },
+    "babel-plugin-transform-inline-environment-variables": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz",
+      "integrity": "sha1-o7CYgzU76LXiM24/8e+KXZP5xIk=",
+      "dev": true
+    },
     "babel-preset-expo": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-8.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "grace",
   "scripts": {
     "start": "expo start",
-    "start-server": "nodemon server/index.js",
+    "start-dev": "ENV='development' expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
@@ -43,10 +43,12 @@
     "redux": "^4.0.5",
     "sequelize": "^6.5.0",
     "victory-native": "^35.3.1",
-    "volleyball": "^1.5.1"
+    "volleyball": "^1.5.1",
+    "expo-constants": "~9.3.3"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "~7.9.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3"
   },
   "private": true
 }

--- a/src/api/grace.js
+++ b/src/api/grace.js
@@ -1,5 +1,5 @@
-// import Constants from "expo-constants";
-// const { manifest } = Constants;
+import Constants from "expo-constants";
+const { manifest } = Constants;
 
 // export let EXPRESS_ROOT_PATH;
 // if (!manifest.debuggerHost) {
@@ -8,8 +8,26 @@
 //   EXPRESS_ROOT_PATH = `http://${manifest.debuggerHost.split(":").shift()}:8080`;
 // }
 
-import axios from "axios"
+import axios from "axios";
+
+let baseURL;
+console.log("here", process.env.ENV)
+if (process.env.ENV === "development") {
+  if (!manifest.debuggerHost) {
+    // local host when using web browser
+    baseURL = `https://localhost:8080/api`;
+    console.log("local ")
+  } else {
+    // to find IP address of local machine
+    baseURL = `http://${manifest.debuggerHost.split(":").shift()}:8080/api`;
+    console.log("ip ")
+  }
+} else {
+  baseURL = "https://sosus-app.herokuapp.com/api";
+  console.log("heroku ")
+}
 
 export const EXPRESS_ROOT_PATH = axios.create({
-  baseURL:'https://sosus-app.herokuapp.com/api'
-})
+  baseURL: baseURL,
+});
+

--- a/src/screens/HomePage.js
+++ b/src/screens/HomePage.js
@@ -72,9 +72,7 @@ export default function HomePage({ navigation }) {
 
   const fetchPoints = async () => {
     try {
-      const res = await EXPRESS_ROOT_PATH.get(
-        `/users/${currentUserUID}`
-      );
+      const res = await EXPRESS_ROOT_PATH.get(`/users/${currentUserUID}`);
       setUser(res.data);
     } catch (error) {
       console.log("get request failed", error);
@@ -142,17 +140,16 @@ export default function HomePage({ navigation }) {
                     {/* <Text style={styles.challengeText}>{item.title}</Text>
                   <Text>{item.category}</Text> */}
 
-                  <TouchableOpacity
-                    onPress={() =>
-                      navigation.navigate("Challenge Tracker", item)
-                    }
-                  >
-                    <Image
-                      source={icons[item.badge]}
-                      style={{ width: 70, height: 70 }}
-                    />
-
-                  </TouchableOpacity>
+                    <TouchableOpacity
+                      onPress={() =>
+                        navigation.navigate("Challenge Tracker", item)
+                      }
+                    >
+                      <Image
+                        source={icons[item.badge]}
+                        style={{ width: 70, height: 70 }}
+                      />
+                    </TouchableOpacity>
 
                     <TouchableOpacity
                       disabled={dailyCompletion[item.id]}


### PR DESCRIPTION
I added functionality to be able to call express routes locally. In order to do it we need to run
`npm run start-dev`
( + `npm run start-server` in backend folder)

To call routes in deployed server, we need to run:
`npm start` 